### PR TITLE
Check if generators are available

### DIFF
--- a/learn-generators.js
+++ b/learn-generators.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --harmony
 
 const workshopper   = require('workshopper'),
       path          = require('path'),

--- a/learn-generators.js
+++ b/learn-generators.js
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
-const workshopper = require('workshopper'),
-      path        = require('path')
-      credits     = require('./credits')
+const workshopper   = require('workshopper'),
+      path          = require('path'),
+      credits       = require('./credits'),
+      hasGenerators = require('has-generators')
+
+if(!hasGenerators) {
+  console.error('You need nodejs >= 0.11.x or iojs >= 1.0.x to work with generators.')
+  process.exit()
+}
 
 function fpath (f) {
     return path.join(__dirname, f)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "colors-tmpl": "~1.0.0",
+    "has-generators": "^1.0.1",
     "workshopper": "^2.1.1",
     "workshopper-exercise": "^2.1.0",
     "workshopper-wrappedexec": "^0.1.2"


### PR DESCRIPTION
This adds a quick check if ES6 generators are available and prompts the user to install another node version instead of showing the menu.
