### PR TITLE
(look sync, do async) Do not call both .throw() and .next() in one callback invocation

### DIFF
--- a/exercises/look_sync_do_async/solution/solution.js
+++ b/exercises/look_sync_do_async/solution/solution.js
@@ -4,7 +4,7 @@ function run (generator) {
   var it = generator(go);
 
   function go (err, result) {
-    if (err) it.throw(err)
+    if (err) return it.throw(err);
     it.next(result);
   }
 


### PR DESCRIPTION
The solution for “LOOK SYNC. DO ASYNC” chapter contains an error.

``` js
function run (generator) {
  var it = generator(go);

  function go (err, result) {
    if (err) it.throw(err)
    it.next(result);
  }

  go();
}
```

If async call results in the error, `go` will both `throw` that error into the generator AND call `next` with the result (which is probably `undefined` in this case). Since `throw` will already continue the execution, that `next` will complete the next yield which is wrong.

In this particular case there is only one yield, but `run` function is supposed to be generic.

You can check this behavior by adding another yield expression somewhere at the end:

``` js
console.log((yield fs.readdir('/tmp', done))[0]);
```

``` js
TypeError: Cannot read property '0' of undefined
```

with this patch being applied:

``` js
.ICE-unix
null
```
