### PR TITLE
Use a Node script for the starting script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node --harmony learn-generators.js"
   },
   "bin": {
-    "learn-generators": "./start"
+    "learn-generators": "./start.js"
   },
   "preferGlobal": true,
   "keywords": [

--- a/start
+++ b/start
@@ -1,8 +1,0 @@
-#!/bin/bash
-# wrapper script to fix shebang none arguments
-# super hacky way %(
-
-prefix=$(npm config get prefix)
-folder="$prefix/lib/node_modules/learn-generators"
-
-node --harmony $folder/learn-generators.js $1 $2

--- a/start.js
+++ b/start.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+var join = require('path').join;
+var spawn = require('child_process').spawn;
+
+var command = process.argv[0];
+
+var args = [
+  '--harmony',
+  join(__dirname, 'learn-generators.js'),
+].concat(process.argv.slice(2));
+
+var opts = {
+  stdio: 'inherit',
+};
+
+spawn(command, args, opts).on('close', process.exit);


### PR DESCRIPTION
This solution is better because:
- it does not require bash;
- it uses absolute path (`__dirname`) therefore it works for global &
  local installs;
- it allows the use of specific version of Node (`n use 0.12 start.js`).
